### PR TITLE
Respect final as literals

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -207,35 +207,12 @@ class BypassFinals
 	public static function removeFinals($code)
 	{
 		if (strpos($code, 'final') !== false) {
-			$tokens = token_get_all($code);
+			$tokens = PHP_VERSION_ID >= 70000 ? token_get_all($code, TOKEN_PARSE) : token_get_all($code);
 			$code = '';
-			$cache = null;
 			foreach ($tokens as $token) {
-				list($type, $value) = is_array($token) ? $token : [$token, $token];
-
-				if ($cache === null) {
-					if ($type === T_FINAL) {
-						$cache = [$value];
-					} else {
-						$code .= $value;
-					}
-
-				} else {
-					switch ($type) {
-						case T_CLASS:
-						case T_FUNCTION:
-							array_shift($cache);
-							// break omitted
-						case '=':
-						case '(':
-							$code .= implode($cache) . $value;
-							$cache = null;
-							break;
-
-						default:
-							$cache[] = $value;
-					}
-				}
+				$code .= is_array($token)
+					? ($token[0] === T_FINAL ? '' : $token[1])
+					: $token;
 			}
 		}
 		return $code;

--- a/tests/BypassFinals/BypassFinals.56.phpt
+++ b/tests/BypassFinals/BypassFinals.56.phpt
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @phpVersion 7
- */
-
 use Tester\Assert;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -13,10 +9,8 @@ Tester\Environment::setup();
 
 DG\BypassFinals::enable();
 
-require __DIR__ . '/fixtures/final.class.php';
+require __DIR__ . '/fixtures/final.class.56.php';
 
-$rc = new ReflectionClass('FinalClass');
+$rc = new ReflectionClass('FinalClass56');
 Assert::false($rc->isFinal());
 Assert::false($rc->getMethod('finalMethod')->isFinal());
-Assert::same(123, FinalClass::FINAL);
-Assert::same(456, (new FinalClass)->final());

--- a/tests/BypassFinals/fixtures/final.class.56.php
+++ b/tests/BypassFinals/fixtures/final.class.56.php
@@ -1,0 +1,8 @@
+<?php
+
+final class FinalClass56
+{
+	final function finalMethod()
+	{
+	}
+}

--- a/tests/BypassFinals/fixtures/final.class.php
+++ b/tests/BypassFinals/fixtures/final.class.php
@@ -2,7 +2,14 @@
 
 final class FinalClass
 {
+	const FINAL = 123;
+
 	final function finalMethod()
 	{
+	}
+
+	function final ()
+	{
+		return 456;
 	}
 }


### PR DESCRIPTION
An idea is that only `final` followed by `class` or `function` is the keyword to remove. If followed by `=` (constant assigning value) or `(` (method signature) it is a literal.