### PR TITLE
Add setWhitelist method to allow controlling which files get replaced.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,6 @@ DG\BypassFinals::setWhitelist([
 DG\BypassFinals::enable();
 ```
 
-This gives you finer control and can solve issues with certain frameworks and libraries. 
+This gives you finer control and can solve issues with certain frameworks and libraries.
 
 If you like it, **[please make a donation now](https://nette.org/make-donation?to=bypass-finals)**. Thank you!

--- a/readme.md
+++ b/readme.md
@@ -38,4 +38,14 @@ DG\BypassFinals::enable();
 You need to enable it before the classes you want to remove the final are loaded. So call it as soon as possible,
 preferably right after `vendor/autoload.php` in loaded.
 
+You can choose to only bypass finals in specific files:
+```php
+DG\BypassFinals::setWhitelist([
+    'relative/path/to/file.php'
+]);
+DG\BypassFinals::enable();
+```
+
+This gives you finer control and can solve issues with certain frameworks and libraries. 
+
 If you like it, **[please make a donation now](https://nette.org/make-donation?to=bypass-finals)**. Thank you!

--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -16,8 +16,8 @@ class BypassFinals
 	/** @var resource|null */
 	private $handle;
 
-    /** @var array|null */
-    private static $pathWhitelist = [];
+	/** @var array|null */
+	private static $pathWhitelist = [];
 
 
 	public static function enable()
@@ -27,10 +27,10 @@ class BypassFinals
 	}
 
 
-    public static function setWhitelist(array $pathWhitelist)
-    {
-        self::$pathWhitelist = $pathWhitelist;
-    }
+	public static function setWhitelist(array $pathWhitelist)
+	{
+		self::$pathWhitelist = $pathWhitelist;
+	}
 
 
 	public function dir_closedir()
@@ -229,17 +229,17 @@ class BypassFinals
 		return $code;
 	}
 
-    private static function pathInWhitelist($path)
-    {
-        if (empty(self::$pathWhitelist)) {
-            return true;
-        }
-        foreach (self::$pathWhitelist as $whitelistItem)
-        {
-            if (substr($path, -strlen($whitelistItem)) === $whitelistItem) {
-                return true;
-            }
-        }
-        return false;
-    }
+	private static function pathInWhitelist($path)
+	{
+		if (empty(self::$pathWhitelist)) {
+			return true;
+		}
+		foreach (self::$pathWhitelist as $whitelistItem)
+		{
+			if (substr($path, -strlen($whitelistItem)) === $whitelistItem) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -229,13 +229,13 @@ class BypassFinals
 		return $code;
 	}
 
+
 	private static function pathInWhitelist($path)
 	{
 		if (empty(self::$pathWhitelist)) {
 			return true;
 		}
-		foreach (self::$pathWhitelist as $whitelistItem)
-		{
+		foreach (self::$pathWhitelist as $whitelistItem) {
 			if (substr($path, -strlen($whitelistItem)) === $whitelistItem) {
 				return true;
 			}

--- a/tests/BypassFinals/BypassFinals.excluded.phpt
+++ b/tests/BypassFinals/BypassFinals.excluded.phpt
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @phpVersion 7
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+
+DG\BypassFinals::enable();
+DG\BypassFinals::setWhitelist([
+    'fixtures/final.class.php'
+]);
+
+require __DIR__ . '/fixtures/final.class.php';
+require __DIR__ . '/fixtures/final.excluded.class.php';
+
+$rc = new ReflectionClass('FinalClass');
+Assert::false($rc->isFinal());
+
+$rc = new ReflectionClass('FinalClassExcluded');
+Assert::true($rc->isFinal());

--- a/tests/BypassFinals/BypassFinals.excluded.phpt
+++ b/tests/BypassFinals/BypassFinals.excluded.phpt
@@ -13,7 +13,7 @@ Tester\Environment::setup();
 
 DG\BypassFinals::enable();
 DG\BypassFinals::setWhitelist([
-	'fixtures/final.class.php'
+	'fixtures/final.class.php',
 ]);
 
 require __DIR__ . '/fixtures/final.class.php';

--- a/tests/BypassFinals/BypassFinals.excluded.phpt
+++ b/tests/BypassFinals/BypassFinals.excluded.phpt
@@ -13,7 +13,7 @@ Tester\Environment::setup();
 
 DG\BypassFinals::enable();
 DG\BypassFinals::setWhitelist([
-    'fixtures/final.class.php'
+	'fixtures/final.class.php'
 ]);
 
 require __DIR__ . '/fixtures/final.class.php';

--- a/tests/BypassFinals/fixtures/final.excluded.class.php
+++ b/tests/BypassFinals/fixtures/final.excluded.class.php
@@ -1,0 +1,8 @@
+<?php
+
+final class FinalClassExcluded
+{
+	final function finalMethod()
+	{
+	}
+}


### PR DESCRIPTION
Reason behind this feature:
Some frameworks stop working because of __DIR__ and such, since the files are now served from tmp. This prompted me to add a more fine-grained control.

I added a test and documentation. The old behavior remains unaffected.