### PR TITLE
Fix wrapper for not existing files for file_put_contents operation

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -3,6 +3,8 @@
 namespace DG;
 
 
+use function file_exists;
+
 /**
  * Removes keyword final from source codes.
  */
@@ -132,7 +134,7 @@ class BypassFinals
 	public function stream_open($path, $mode, $options, &$openedPath)
 	{
 		$usePath = (bool) ($options & STREAM_USE_PATH);
-		if (self::pathInWhitelist($path) && pathinfo($path, PATHINFO_EXTENSION) === 'php') {
+		if (self::pathInWhitelist($path) && pathinfo($path, PATHINFO_EXTENSION) === 'php' && file_exists($path)) {
 			$content = $this->native('file_get_contents', $path, $usePath, $this->context);
 			if ($content === false) {
 				return false;

--- a/tests/BypassFinals/BypassFinals.not_existing_file.phpt
+++ b/tests/BypassFinals/BypassFinals.not_existing_file.phpt
@@ -1,0 +1,16 @@
+<?php
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+
+DG\BypassFinals::enable();
+
+Assert::noError(function () { // recursive
+	file_put_contents(__DIR__ . '/fixtures/not_existing_class.php', 'test');
+});
+
+@unlink(__DIR__ . '/fixtures/not_existing_class.php');


### PR DESCRIPTION
When using snapshot testing with bypass-finals we can see that file_put_contents wrapped not correct. This pr fix this by checking for file existance before reading content