### PR TITLE
Fix type error on touch

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -121,7 +121,7 @@ class BypassFinals
 		switch ($option) {
 			case STREAM_META_TOUCH:
 				$value += [null, null];
-				return $this->native('touch', $path, $value[0], $value[1]);
+				return $this->native('touch', $path, $value[0] ?? time(), $value[1] ?? time());
 			case STREAM_META_OWNER_NAME:
 			case STREAM_META_OWNER:
 				return $this->native('chown', $path, $value);

--- a/tests/BypassFinals/BypassFinals.lock.phpt
+++ b/tests/BypassFinals/BypassFinals.lock.phpt
@@ -12,3 +12,7 @@ DG\BypassFinals::enable();
 Assert::noError(function () {
 	file_put_contents(__DIR__ . '/fixtures/tmp', 'foo', LOCK_EX);
 });
+
+Assert::noError(function () {
+    unlink(__DIR__ . '/fixtures/tmp');
+});

--- a/tests/BypassFinals/BypassFinals.touch.phpt.php
+++ b/tests/BypassFinals/BypassFinals.touch.phpt.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+DG\BypassFinals::enable();
+
+Assert::noError(function () {
+    touch('known');
+});
+
+Assert::noError(function () {
+    touch('known', time());
+});
+
+Assert::error(function () {
+    touch('known', null);
+}, TypeError::class);
+
+Assert::noError(function () {
+    unlink('known');
+});


### PR DESCRIPTION
When using strict mode a type error is thrown: `TypeError: touch() expects parameter 2 to be int, null given`

This closes #18