### PR TITLE
Bugfix: Make sure to restore the stream wrapper even when an exception is thrown

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -223,10 +223,12 @@ class BypassFinals
 	private function native(string $func)
 	{
 		stream_wrapper_restore(self::PROTOCOL);
-		$res = $func(...array_slice(func_get_args(), 1));
-		stream_wrapper_unregister(self::PROTOCOL);
-		stream_wrapper_register(self::PROTOCOL, __CLASS__);
-		return $res;
+		try {
+			return $func(...array_slice(func_get_args(), 1));
+		} finally {
+			stream_wrapper_unregister(self::PROTOCOL);
+			stream_wrapper_register(self::PROTOCOL, __CLASS__);
+		}
 	}
 
 

--- a/tests/BypassFinals/BypassFinals.exception.phpt
+++ b/tests/BypassFinals/BypassFinals.exception.phpt
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+DG\BypassFinals::enable();
+
+$customHandler = static function ($type, $msg, $file, $line) {
+	throw new \ErrorException($msg, 0, $type, $file, $line);
+};
+set_error_handler($customHandler);
+
+try {
+	include 'file/no/found';
+} catch (\ErrorException $e) {
+	// Custom logic if file is missing
+} finally {
+	restore_error_handler();
+}
+
+require __DIR__ . '/fixtures/final.class.php';
+$rc = new ReflectionClass('FinalClass');
+Assert::false($rc->isFinal());


### PR DESCRIPTION
If a native function throws an exception, then we will not restore the stream wrapper. With this patch we will throw the exception AND restore the stream wrapper. 

To reproduce: 

```php
BypassFinals::enable();

$customHandler = static function ($type, $msg, $file, $line) {
    throw new \ErrorException($msg, 0, $type, $file, $line);
};
set_error_handler($customHandler);

new Foo(); // This is rewritten
try {
    include 'non/existing/path.php';
} finally {
    restore_error_handler();
}

new Bar(); // This is still final!
```

It took me a good 2 hours to find this bug =)

