### PR TITLE
allow inheritance by using static instead of self and making properti…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 tests/**/output/
+/.idea


### PR DESCRIPTION
allow inheritance by using static instead of self and making properties protected.
Method ::removeFinals() is receiving the path because it might be needed in a child class that will catch parse errors in token_get_all() and report the failed file.