### PR TITLE
Updated stream_set_option signature

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -175,7 +175,7 @@ class BypassFinals
 	}
 
 
-	public function stream_set_option(int $option, int $arg1, int $arg2): bool
+	public function stream_set_option(int $option, int $arg1, ?int $arg2): bool
 	{
 		return false;
 	}


### PR DESCRIPTION
The third argument has to be nullable. While the docs specify a signature lof `public streamWrapper::stream_set_option ( int $option , int $arg1 , int $arg2 ) : bool` they also say this: ` arg2:  If option is STREAM_OPTION_BLOCKING: This option is not set.`

The third argument has to be nullable. While the docs specify a signature lof public streamWrapper::stream_set_option ( int $option , int $arg1 , int $arg2 ) : bool they also say this: arg2: If option is STREAM_OPTION_BLOCKING: This option is not set.

We get errors like this `TypeError: Argument 3 passed to DG\BypassFinals::stream_set_option() must be of the type int, null given` because of this.