### PR TITLE
Adjust stream_tell return type hint

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -204,7 +204,7 @@ class BypassFinals
 	}
 
 
-	public function stream_tell(): int
+	public function stream_tell()
 	{
 		return ftell($this->handle);
 	}


### PR DESCRIPTION
As the PHP built-in ftell (which is wrapped by stream_tell) has mixed return types (int|false), enforcing int can sometimes lead to run-time errors.

However, maintaining PHP 7.x compatibility however (which is still maintained), we cannot use union return type hints (int|false), as that is a rather new feature in PHP 8. Hence, the constraint has been removed similarly to the `stream_stat()` method above...