### PR TITLE
fix: allow using alternative stream handlers (Infection)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
             fail-fast: false
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,11 @@ DG\BypassFinals::setWhitelist([
 
 This gives you finer control and can solve issues with certain frameworks and libraries.
 
+You can try to increase performance by using the cache (the directory must exist):
+
+```php
+DG\BypassFinals::$cacheDir = __DIR__ . '/tmp';
+```
 
 Support Project
 ---------------

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The recommended way to install is through Composer:
 composer require dg/bypass-finals --dev
 ```
 
-It requires PHP version 7.1 (or 5.6 in case of release 1.1) and supports PHP up to 8.0.
+It requires PHP version 7.1 (or 5.6 in case of release 1.1) and supports PHP up to 8.1.
 
 
 Usage

--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -34,6 +34,7 @@ class BypassFinals
 		foreach ($whitelist as &$mask) {
 			$mask = strtr($mask, '\\', '/');
 		}
+
 		self::$pathWhitelist = $whitelist;
 	}
 
@@ -136,6 +137,7 @@ class BypassFinals
 			case STREAM_META_ACCESS:
 				return $this->native('chmod', $path, $value);
 		}
+
 		return false;
 	}
 
@@ -250,6 +252,7 @@ class BypassFinals
 				? ($token[0] === T_FINAL ? '' : $token[1])
 				: $token;
 		}
+
 		return $code;
 	}
 
@@ -262,6 +265,7 @@ class BypassFinals
 				return true;
 			}
 		}
+
 		return false;
 	}
 }

--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -207,7 +207,7 @@ class BypassFinals
 	}
 
 
-	public function stream_tell(): int
+	public function stream_tell()
 	{
 		return ftell($this->handle);
 	}

--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -160,7 +160,6 @@ class BypassFinals
 				while (!self::$prevWrapper->stream_eof()) {
 					$content .= self::$prevWrapper->stream_read(8192);
 				}
-
 				self::$prevWrapper->stream_close();
 			} else {
 				$content = $this->native('file_get_contents', $path, $usePath, $this->context);
@@ -169,7 +168,7 @@ class BypassFinals
 				return false;
 			}
 			$modified = self::cachedRemoveFinals($content);
-			if ($modified !== $content) {
+			if ($modified !== $content || (self::$prevWrapper && $content !== $this->native('file_get_contents', $path, $usePath, $this->context))) {
 				$this->handle = tmpfile();
 				$this->native('fwrite', $this->handle, $modified);
 				$this->native('fseek', $this->handle, 0);

--- a/tests/BypassFinals/BypassFinals.isPathInWhiteList.phpt
+++ b/tests/BypassFinals/BypassFinals.isPathInWhiteList.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test isPathInWhiteList()
 
 declare(strict_types=1);

--- a/tests/BypassFinals/BypassFinals.magic-constants.phpt
+++ b/tests/BypassFinals/BypassFinals.magic-constants.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test that magic contants are not affected by BypassFinals
 
 declare(strict_types=1);

--- a/tests/BypassFinals/BypassFinals.phpt
+++ b/tests/BypassFinals/BypassFinals.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test that BypassFinals works
 
 declare(strict_types=1);

--- a/tests/BypassFinals/BypassFinals.setWhitelist.phpt
+++ b/tests/BypassFinals/BypassFinals.setWhitelist.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test setWhitelist()
 
 declare(strict_types=1);

--- a/tests/BypassFinals/native.errors.phpt
+++ b/tests/BypassFinals/native.errors.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test native php functions - for comparison with overloaded.errors.phpt
 
 declare(strict_types=1);

--- a/tests/BypassFinals/overloaded.errors.phpt
+++ b/tests/BypassFinals/overloaded.errors.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test overloaded php functions
 
 declare(strict_types=1);

--- a/tests/BypassFinals/overloaded.exception.phpt
+++ b/tests/BypassFinals/overloaded.exception.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test to make sure to restore the stream wrapper even when an exception is throw
 
 declare(strict_types=1);
@@ -12,13 +13,13 @@ Tester\Environment::setup();
 DG\BypassFinals::enable();
 
 $customHandler = static function ($type, $msg, $file, $line) {
-	throw new \ErrorException($msg, 0, $type, $file, $line);
+	throw new ErrorException($msg, 0, $type, $file, $line);
 };
 set_error_handler($customHandler);
 
 try {
 	include 'file/no/found';
-} catch (\ErrorException $e) {
+} catch (ErrorException $e) {
 	// Custom logic if file is missing
 } finally {
 	restore_error_handler();

--- a/tests/BypassFinals/overloaded.lock.phpt
+++ b/tests/BypassFinals/overloaded.lock.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test overloaded file_put_contents() with lock
 
 declare(strict_types=1);

--- a/tests/BypassFinals/overloaded.mkdir.phpt
+++ b/tests/BypassFinals/overloaded.mkdir.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test overloaded mkdir()
 
 declare(strict_types=1);

--- a/tests/BypassFinals/overloaded.touch.phpt
+++ b/tests/BypassFinals/overloaded.touch.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test overloaded touch()
 
 declare(strict_types=1);

--- a/tests/BypassFinals/removeFinals.not-existing-file.phpt
+++ b/tests/BypassFinals/removeFinals.not-existing-file.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test that removing finals is done only in reading mode
 
 declare(strict_types=1);

--- a/tests/BypassFinals/removeFinals.syntax-error.phpt
+++ b/tests/BypassFinals/removeFinals.syntax-error.phpt
@@ -1,4 +1,5 @@
 <?php
+
 // test that removeFinals() catches token_get_all() exception
 
 declare(strict_types=1);


### PR DESCRIPTION
This is a PR from comments made by @dg and @maks-rafalko in #9. It's confirmed to fix issues with using Infection and BypassFinals together, tested on two of my projects.