### PR TITLE
Fix bug #44

### DIFF
--- a/src/NativeWrapper.php
+++ b/src/NativeWrapper.php
@@ -206,6 +206,9 @@ final class NativeWrapper
 		} catch (\RuntimeException $e) {
 			// SplFileInfo::isFile throws exception
 			return false;
+		} catch (\ErrorException $e) {
+			// Warning was converted into an exception by an external error handler
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Add a catch to cover exceptions thrown in error handlers while handling a PHP warning emitted in some cases with stat on non-existent files.

See bug #44 