### PR TITLE
fail open_stream when $path is directory

### DIFF
--- a/src/MutatingWrapper.php
+++ b/src/MutatingWrapper.php
@@ -25,9 +25,9 @@ final class MutatingWrapper
 
 	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
 	{
-        if(is_dir($path)) {
+		if(is_dir($path)) {
             return false;
-        }
+		}
 
 		$this->wrapper = $this->createUnderlyingWrapper();
 		if (!$this->wrapper->stream_open($path, $mode, $options, $openedPath)) {

--- a/src/MutatingWrapper.php
+++ b/src/MutatingWrapper.php
@@ -25,6 +25,10 @@ final class MutatingWrapper
 
 	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
 	{
+        if(is_dir($path)) {
+            return false;
+        }
+
 		$this->wrapper = $this->createUnderlyingWrapper();
 		if (!$this->wrapper->stream_open($path, $mode, $options, $openedPath)) {
 			return false;

--- a/tests/BypassFinals/native.errors.phpt
+++ b/tests/BypassFinals/native.errors.phpt
@@ -26,6 +26,10 @@ Assert::error(function () {
 }, E_WARNING);
 
 Assert::error(function () {
+    file_get_contents(__DIR__);
+}, E_NOTICE);
+
+Assert::error(function () {
 	file_put_contents(__DIR__, 'content');
 }, E_WARNING);
 

--- a/tests/BypassFinals/overloaded.errors.phpt
+++ b/tests/BypassFinals/overloaded.errors.phpt
@@ -29,8 +29,12 @@ Assert::error(function () {
 }, [E_WARNING, E_WARNING]);
 
 Assert::error(function () {
+    file_get_contents(__DIR__);
+}, [E_WARNING]);
+
+Assert::error(function () {
 	file_put_contents(__DIR__, 'content');
-}, [E_WARNING, E_WARNING]);
+}, [E_WARNING]);
 
 Assert::error(function () {
 	file('unknown');


### PR DESCRIPTION
Without this condition the Wrapper emits E_NOTICE:
`E_NOTICE (fread(): Read of 8192 bytes failed with errno=21 Is a directory)`