### PR TITLE
Make PHPUnitExtension configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 tests/**/cache/
 tests/**/output/
+/.idea

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,18 @@ For integration with PHPUnit 10 or newer, simply add BypassFinals as an extensio
 </extensions>
 ```
 
+Optionally you can configure BypassFinals in your `phpunit.xml` file:
+
+```xml
+<extensions>
+    <bootstrap class="Tests\BypassFinalsPHPUnitExtension">
+        <parameter name="bypassFinal" value="true"/>
+        <parameter name="bypassReadOnly" value="false"/>
+        <parameter name="cacheDirectory" value="./cache"/>
+    </bootstrap>
+</extensions>
+```
+
  <!---->
 
 Troubleshooting

--- a/src/PHPUnitExtension.php
+++ b/src/PHPUnitExtension.php
@@ -22,6 +22,59 @@ final class PHPUnitExtension implements Extension
 		BypassFinals::denyPaths([
 			'*/vendor/phpunit/*',
 		]);
-		BypassFinals::enable();
-	}
+        BypassFinals::enable(
+            bypassReadOnly: $this->shouldBypassReadonly($parameters) ?? true,
+            bypassFinal: $this->shouldBypassFinal($parameters) ?? true,
+        );
+
+        if ($parameters->has('cacheDirectory')) {
+            BypassFinals::setCacheDirectory($parameters->get('cacheDirectory'));
+        }
+    }
+
+    private function shouldBypassReadonly(ParameterCollection $parameters): ?bool
+    {
+        if (! $parameters->has('bypassReadOnly')) {
+            return null;
+        }
+
+        return $this->parseBoolean($parameters->get('bypassReadOnly'));
+    }
+
+    private function shouldBypassFinal(ParameterCollection $parameters): ?bool
+    {
+        if (! $parameters->has('bypassFinal')) {
+            return null;
+        }
+
+        return $this->parseBoolean($parameters->get('bypassFinal'));
+    }
+
+    /**
+     * Parse a boolean-like value safely.
+     */
+    private function parseBoolean(mixed $value): ?bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $value = strtolower($value);
+
+            if (in_array($value, ['1', 'true', 'yes'], true)) {
+                return true;
+            }
+
+            if (in_array($value, ['0', 'false', 'no'], true)) {
+                return false;
+            }
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value === 1;
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
I noticed using this package via PHPUnit can be as easy as adding an extension, however we use `BypassFinals::enable(bypassReadOnly: false);` in our project and the extension doesn't allow any config and defaults to bypassing readonly.

This PR adds the option to add [parameters](https://docs.phpunit.de/en/10.5/configuration.html#the-parameter-element) to `phpunit.xml`