### PR TITLE
Fix debugInfo() output for bypass tokens

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -233,8 +233,8 @@ final class BypassFinals
 		echo "BypassFinals Debug Information\n";
 		echo "------------------------------\n\n";
 		echo "Configuration:\n";
-		echo "  Bypass 'final': " . (isset(self::$tokens[T_READONLY]) ? 'enabled' : 'disabled') . "\n";
-		echo "  Bypass 'readonly': " . (isset(self::$tokens[T_FINAL]) ? 'enabled' : 'disabled') . "\n";
+		echo "  Bypass 'final': " . (isset(self::$tokens[T_FINAL]) ? 'enabled' : 'disabled') . "\n";
+		echo "  Bypass 'readonly': " . (isset(self::$tokens[T_READONLY]) ? 'enabled' : 'disabled') . "\n";
 
 		echo "\nFrom where BypassFinals::enable() was started:\n";
 		foreach (self::$enableCallStack as $index => $frame) {


### PR DESCRIPTION
The Configuration section of debugInfo() was checking T_FINAL and T_READONLY against the wrong labels, reporting the opposite of the actual configuration.