### PR TITLE
fix: clear stat cache after is_dir() check in stream_open()

### DIFF
--- a/src/MutatingWrapper.php
+++ b/src/MutatingWrapper.php
@@ -30,6 +30,9 @@ final class MutatingWrapper
 			return false;
 		}
 
+		// is_dir() populates the stat cache; clear it so subsequent stat calls return fresh data
+		clearstatcache(true, $path);
+
 		$this->wrapper = $this->createUnderlyingWrapper();
 		if (!$this->wrapper->stream_open($path, $mode, $options, $openedPath)) {
 			return false;

--- a/tests/BypassFinals/overloaded.stat-cache.phpt
+++ b/tests/BypassFinals/overloaded.stat-cache.phpt
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+// test that is_dir() inside stream_open() does not poison the stat cache (issue #67)
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+DG\BypassFinals::enable(bypassReadOnly: false);
+
+$filename = tempnam(sys_get_temp_dir(), 'bypass-finals-test');
+$handle = fopen($filename, 'wb+');
+fputcsv($handle, ['TestCol1', 'TestCol2', 'TestCol3']);
+fclose($handle);
+
+Assert::true(filesize($filename) > 0);
+
+unlink($filename);


### PR DESCRIPTION
is_dir() populates PHP's stat cache with the file state at open time. Any subsequent stat call (filesize, filemtime, etc.) then returns stale data after writes to that path.

clearstatcache(true, $path) drops the cached entry so callers always get fresh values from the OS.

Closes #67