### PR TITLE
fix: create cache directory recursively if it does not exist

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -143,6 +143,7 @@ final class BypassFinals
 
 		$code = self::removeTokens($code);
 
+		@mkdir(self::$cacheDir, 0777, true);
 		if (@$wrapper->stream_open(self::$cacheDir . '/' . $hash, 'x')) { // @ may exist
 			flock($wrapper->handle, LOCK_EX);
 			fwrite($wrapper->handle, $code);

--- a/tests/BypassFinals/BypassFinals.cache-autocreate.phpt
+++ b/tests/BypassFinals/BypassFinals.cache-autocreate.phpt
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+// test that setCacheDirectory() creates missing directories recursively (issue #66)
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+
+$dir = __DIR__ . '/cache-nested/sub';
+
+DG\BypassFinals::setCacheDirectory($dir);
+DG\BypassFinals::enable();
+
+require __DIR__ . '/fixtures/final.class.php';
+
+Assert::true(is_dir($dir));
+
+$rc = new ReflectionClass('FinalClass');
+Assert::false($rc->isFinal());
+
+// cleanup
+array_map('unlink', glob($dir . '/*'));
+rmdir($dir);
+rmdir(dirname($dir));


### PR DESCRIPTION
fopen() in write mode fails when the cache directory is absent, which happens when the path is gitignored and not pre-created (e.g. .cache/).

@mkdir with recursive=true creates all missing intermediate directories before writing the first cache entry.

Closes #66