### PR TITLE
fix: consolidate cache I/O in a single native stream wrapper cycle

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -132,23 +132,36 @@ final class BypassFinals
 	 */
 	private static function removeTokensCached(string $code): string
 	{
-		$wrapper = new NativeWrapper;
 		$hash = sha1($code . implode(',', self::$tokens));
-		if (@$wrapper->stream_open(self::$cacheDir . '/' . $hash, 'r')) { // @ may not exist
-			flock($wrapper->handle, LOCK_SH);
-			if ($res = stream_get_contents($wrapper->handle)) {
-				return $res;
+		$file = self::$cacheDir . '/' . $hash;
+
+		// All cache I/O in a single native context to avoid multiple stream_wrapper_restore
+		// cycles inside an already-active MutatingWrapper stream_open callback, which
+		// corrupts PHP's internal stream wrapper state.
+		stream_wrapper_restore(NativeWrapper::Protocol);
+		try {
+			if ($handle = @fopen($file, 'r')) { // @ may not exist
+				flock($handle, LOCK_SH);
+				$cached = stream_get_contents($handle);
+				fclose($handle);
+				if ($cached) {
+					return $cached;
+				}
 			}
+
+			$code = self::removeTokens($code);
+
+			if ($handle = @fopen($file, 'x')) { // @ may exist
+				flock($handle, LOCK_EX);
+				fwrite($handle, $code);
+				fclose($handle);
+			}
+
+			return $code;
+		} finally {
+			stream_wrapper_unregister(NativeWrapper::Protocol);
+			stream_wrapper_register(NativeWrapper::Protocol, MutatingWrapper::class);
 		}
-
-		$code = self::removeTokens($code);
-
-		if (@$wrapper->stream_open(self::$cacheDir . '/' . $hash, 'x')) { // @ may exist
-			flock($wrapper->handle, LOCK_EX);
-			fwrite($wrapper->handle, $code);
-		}
-
-		return $code;
 	}
 
 

--- a/tests/BypassFinals/BypassFinals.cache.attributes.phpt
+++ b/tests/BypassFinals/BypassFinals.cache.attributes.phpt
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+/** @phpVersion 8.0 */
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+
+@mkdir($dir = __DIR__ . '/cache');
+DG\BypassFinals::setCacheDirectory($dir);
+
+DG\BypassFinals::enable();
+
+require __DIR__ . '/fixtures/final.attributes.class.php';
+
+// Both methods must be discoverable (issue #55: cache caused one method to vanish)
+$rc = new ReflectionClass('AttributedClass');
+Assert::false($rc->isFinal());
+
+$methods = array_map(fn($m) => $m->getName(), $rc->getMethods(ReflectionMethod::IS_PUBLIC));
+Assert::contains('testFirst', $methods);
+Assert::contains('testSecond', $methods);
+
+// PHP attribute on testSecond must be intact after final-stripping via cache
+$rm = new ReflectionMethod('AttributedClass', 'testSecond');
+$attrs = $rm->getAttributes(MyTestDepends::class);
+Assert::count(1, $attrs);
+Assert::same('testFirst', $attrs[0]->newInstance()->method);

--- a/tests/BypassFinals/fixtures/final.attributes.class.php
+++ b/tests/BypassFinals/fixtures/final.attributes.class.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+#[Attribute]
+final class MyTestDepends
+{
+	public function __construct(public readonly string $method)
+	{
+	}
+}
+
+final class AttributedClass
+{
+	public function testFirst(): void
+	{
+	}
+
+	#[MyTestDepends('testFirst')]
+	public function testSecond(): void
+	{
+	}
+}

--- a/tests/BypassFinals/overloaded.opendir.phpt
+++ b/tests/BypassFinals/overloaded.opendir.phpt
@@ -21,6 +21,7 @@ sort($files);
 Assert::same([
 	'.',
 	'..',
+	'final.attributes.class.php',
 	'final.class.php',
 	'final.excluded.class.php',
 	'final.readonly.class.php',


### PR DESCRIPTION
removeTokensCached() was calling NativeWrapper::stream_open() twice or three times, each triggering a stream_wrapper_restore/unregister/register cycle inside an already-active MutatingWrapper::stream_open() callback. These nested cycles corrupt PHP's internal stream wrapper state, causing PHPUnit's #[Depends] resolution to silently drop dependent tests.

All cache file operations are now performed inside a single native context, reducing the churn from 3 cycles to 1 and eliminating the state corruption.

Closes #55