### PR TITLE
fix: replace visibility-less readonly with public instead of removing it

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -168,8 +168,16 @@ final class BypassFinals
 		foreach ($tokens as $i => $token) {
 			if (!is_array($token)) {
 				$code .= $token;
-			} elseif (!isset(self::$tokens[$token[0]]) || !self::shouldRemoveToken($tokens, $i)) {
+			} elseif (!isset(self::$tokens[$token[0]])) {
 				$code .= $token[1];
+			} else {
+				$action = self::shouldRemoveToken($tokens, $i);
+				if ($action === false) {
+					$code .= $token[1];
+				} elseif (is_string($action)) {
+					$code .= $action;
+				}
+				// true = remove, nothing added
 			}
 		}
 
@@ -178,9 +186,12 @@ final class BypassFinals
 
 
 	/**
-	 * Determines if a token should be removed based on its context.
+	 * Determines if a token should be removed or replaced based on its context.
+	 * Returns true to remove, false to keep, or a string to use as replacement.
+	 *
+	 * @return bool|string
 	 */
-	private static function shouldRemoveToken(array $tokens, int $index): bool
+	private static function shouldRemoveToken(array $tokens, int $index)
 	{
 		$tokenType = $tokens[$index][0];
 
@@ -194,7 +205,40 @@ final class BypassFinals
 				return is_array($token) && in_array($token[0], [T_CLASS, T_FUNCTION, T_READONLY], true);
 			}
 		} elseif ($tokenType === T_READONLY) {
-			return true;
+			// "readonly class" / "final readonly class": next non-whitespace is T_CLASS -> remove
+			for ($j = $index + 1; $j < count($tokens); $j++) {
+				$t = $tokens[$j];
+				if (is_array($t) && $t[0] === T_WHITESPACE) {
+					continue;
+				}
+				if (is_array($t) && $t[0] === T_CLASS) {
+					return true;
+				}
+				break;
+			}
+
+			// Property or promoted parameter: scan backwards for a visibility modifier.
+			// If none is found, replace "readonly" with "public" to preserve the promoted
+			// property (a visibility-less "readonly T $x" in a constructor is valid PHP 8.4+,
+			// but stripping readonly without adding public would turn it into a plain argument).
+			for ($j = $index - 1; $j >= 0; $j--) {
+				$t = $tokens[$j];
+				if (!is_array($t)) {
+					return 'public';
+				}
+				if ($t[0] === T_WHITESPACE || $t[0] === T_COMMENT || $t[0] === T_DOC_COMMENT) {
+					continue;
+				}
+				if (in_array($t[0], [T_PUBLIC, T_PROTECTED, T_PRIVATE], true)) {
+					return true;
+				}
+				if ($t[0] === T_STATIC) {
+					continue;
+				}
+				return 'public';
+			}
+
+			return 'public';
 		}
 
 		return false;

--- a/tests/BypassFinals/BypassFinals.no-visibility-readonly.phpt
+++ b/tests/BypassFinals/BypassFinals.no-visibility-readonly.phpt
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/** @phpVersion 8.4 */
+
+// Regression test for issue #49:
+// "readonly T $x" without explicit visibility is valid PHP 8.4+ constructor promotion.
+// Stripping readonly would turn it into a plain argument; it must become "public T $x" instead.
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+
+DG\BypassFinals::enable();
+
+require __DIR__ . '/fixtures/final.readonly.noinit.class.php';
+
+$rc = new ReflectionClass('ReadonlyNoVisibility');
+Assert::false($rc->isFinal());
+
+$obj = new ReadonlyNoVisibility('hello', 'world');
+
+// Both must be accessible as promoted properties, not lost as plain arguments
+Assert::same('hello', $obj->a);
+Assert::same('world', $obj->b);

--- a/tests/BypassFinals/fixtures/final.readonly.noinit.class.php
+++ b/tests/BypassFinals/fixtures/final.readonly.noinit.class.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+final class ReadonlyNoVisibility
+{
+	public function __construct(
+		readonly string $a,
+		public readonly string $b,
+	) {
+	}
+}

--- a/tests/BypassFinals/overloaded.opendir.phpt
+++ b/tests/BypassFinals/overloaded.opendir.phpt
@@ -24,5 +24,6 @@ Assert::same([
 	'final.class.php',
 	'final.excluded.class.php',
 	'final.readonly.class.php',
+	'final.readonly.noinit.class.php',
 	'magic.constants.php',
 ], $files);


### PR DESCRIPTION
"readonly T $x" without an explicit visibility modifier is valid PHP 8.4+ constructor promotion syntax. Stripping readonly entirely turned the promoted property into a plain constructor argument, making $this->x inaccessible.

shouldRemoveToken now returns bool|string: when readonly has no preceding visibility modifier it returns 'public' (replace) rather than true (remove), preserving the promoted property semantics.

Closes #49