### PR TITLE
test: add regression test for proc_open file descriptor redirect

### DIFF
--- a/tests/BypassFinals/BypassFinals.proc_open.file_descriptor.phpt
+++ b/tests/BypassFinals/BypassFinals.proc_open.file_descriptor.phpt
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+// Regression test for issue #43:
+// proc_open() with a ['file', path, mode] descriptor spec must redirect subprocess
+// output to the file. Without the fix, stream_close() closes the underlying FD
+// before the child inherits it, causing dup2 to fail and output to appear on the
+// wrong stream.
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+
+DG\BypassFinals::enable();
+
+$tmpFile = tempnam(sys_get_temp_dir(), 'bypass_');
+
+$proc = proc_open(
+	'echo bypass_finals_test_output',
+	[
+		0 => ['pipe', 'r'],
+		1 => ['file', $tmpFile, 'w'],
+		2 => STDERR,
+	],
+	$pipes,
+);
+
+Assert::notSame(false, $proc);
+proc_close($proc);
+
+$content = file_get_contents($tmpFile);
+@unlink($tmpFile);
+
+Assert::contains('bypass_finals_test_output', $content);


### PR DESCRIPTION
Verifies that proc_open() with ['file', path, mode] descriptor spec correctly redirects subprocess output to the target file when BypassFinals is active (issue #43).

The underlying fix (NativeWrapper::stream_close preserving the FD when called from proc_open context) was already present since bc40572.

Closes #43