### PR TITLE
feat: add bootstrap.php for early activation before vendor/autoload.php

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,21 @@ Optionally you can configure BypassFinals in your `phpunit.xml` file:
 Troubleshooting
 ---------------
 
-If you encounter issues with BypassFinals not working as expected, you can use the `debugInfo()` method to gain insights into its internal state. Calling this method will output valuable information to help diagnose the problem:
+**Class is still final after enabling BypassFinals**
+
+BypassFinals can only strip the `final` keyword from files loaded *after* `enable()` is called. If a class is loaded before that — for example via a `files` entry in a package's `autoload` configuration, which Composer loads during `require 'vendor/autoload.php'` — the class will remain final.
+
+To handle this, include `src/bootstrap.php` *before* `vendor/autoload.php` in your test bootstrap file:
+
+```php
+// tests/bootstrap.php
+require __DIR__ . '/../vendor/dg/bypass-finals/src/bootstrap.php';
+require __DIR__ . '/../vendor/autoload.php';
+```
+
+This activates the stream wrapper early enough to intercept every file loaded during autoloading.
+
+If you encounter other issues with BypassFinals not working as expected, you can use the `debugInfo()` method to gain insights into its internal state. Calling this method will output valuable information to help diagnose the problem:
 
 ```php
 DG\BypassFinals::debugInfo();

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+// Designed to be loaded BEFORE vendor/autoload.php so that classes
+// registered in autoload.files are processed by BypassFinals.
+//
+// Usage in tests/bootstrap.php:
+//   require __DIR__ . '/../vendor/dg/bypass-finals/src/bootstrap.php';
+//   require __DIR__ . '/../vendor/autoload.php';
+
+require_once __DIR__ . '/NativeWrapper.php';
+require_once __DIR__ . '/MutatingWrapper.php';
+require_once __DIR__ . '/BypassFinals.php';
+
+\DG\BypassFinals::enable();

--- a/tests/BypassFinals/BypassFinals.bootstrap.phpt
+++ b/tests/BypassFinals/BypassFinals.bootstrap.phpt
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+// Regression test for issue #58:
+// bootstrap.php can be loaded BEFORE vendor/autoload.php so that classes
+// registered in autoload.files have their final keyword stripped.
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+
+$bootstrap = realpath(__DIR__ . '/../../src/bootstrap.php');
+$autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+$fixture = realpath(__DIR__ . '/fixtures/final.class.php');
+
+$script = tempnam(sys_get_temp_dir(), 'bypass_');
+file_put_contents($script, <<<PHP
+<?php
+require '$bootstrap';
+require '$autoload';
+require '$fixture';
+class EarlyLoadTest extends FinalClass {}
+echo 'success';
+PHP);
+
+$output = shell_exec('php ' . escapeshellarg($script));
+@unlink($script);
+
+Assert::same('success', trim($output));


### PR DESCRIPTION
Classes registered in a package's autoload.files are loaded during require 'vendor/autoload.php', before any user code runs. Calling BypassFinals::enable() afterwards cannot strip final from those classes.

bootstrap.php loads the BypassFinals internals directly (no autoloader needed) and calls enable(), so users can require it before vendor/autoload.php to intercept every file loaded during autoloading.

Closes #58