### PR TITLE
fix: defer stream_eof() until an empty read confirms EOF

### DIFF
--- a/src/NativeWrapper.php
+++ b/src/NativeWrapper.php
@@ -23,6 +23,9 @@ final class NativeWrapper
 	/** @var bool */
 	private $isProcOpen = false;
 
+	/** @var bool  EOF is deferred until an empty read confirms it, matching native file:// handler semantics */
+	private $eofAfterEmptyRead = false;
+
 	public function dir_closedir(): void
 	{
 		closedir($this->handle);
@@ -103,7 +106,7 @@ final class NativeWrapper
 
 	public function stream_eof(): bool
 	{
-		return feof($this->handle);
+		return $this->eofAfterEmptyRead;
 	}
 
 
@@ -155,15 +158,24 @@ final class NativeWrapper
 
 	public function stream_read(int $count)
 	{
-		return fread($this->handle, $count);
+		$data = fread($this->handle, $count);
+		if ($data === '' || $data === false) {
+			$this->eofAfterEmptyRead = true;
+		}
+		return $data;
 	}
 
 
 	public function stream_seek(int $offset, int $whence = SEEK_SET): bool
 	{
-		return stream_get_meta_data($this->handle)['seekable']
-			? fseek($this->handle, $offset, $whence) === 0
-			: false;
+		if (!stream_get_meta_data($this->handle)['seekable']) {
+			return false;
+		}
+		$result = fseek($this->handle, $offset, $whence) === 0;
+		if ($result) {
+			$this->eofAfterEmptyRead = false;
+		}
+		return $result;
 	}
 
 

--- a/tests/BypassFinals/overloaded.spl-file-object.phpt
+++ b/tests/BypassFinals/overloaded.spl-file-object.phpt
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+// Regression test for issue #50:
+// SplFileObject::seek(PHP_INT_MAX)->key() must return the same line count
+// with and without BypassFinals active. The stream wrapper was previously
+// reporting EOF too early (after the last non-empty read), causing the count
+// to be off by one for files ending with a newline.
+
+use Tester\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+Tester\Environment::setup();
+
+
+$tmpFile = tempnam(sys_get_temp_dir(), 'bypass_spl_');
+file_put_contents($tmpFile, implode("\n", range(1, 10)) . "\n");
+
+$countLines = function (string $path): int {
+	$spl = new SplFileObject($path);
+	$spl->seek(PHP_INT_MAX);
+	return $spl->key();
+};
+
+$before = $countLines($tmpFile);
+
+DG\BypassFinals::enable();
+
+$after = $countLines($tmpFile);
+
+@unlink($tmpFile);
+
+Assert::same($before, $after);


### PR DESCRIPTION
fread() can return data AND cause feof() to return true in the same call when it exhausts the file. The stream wrapper was reporting stream_eof()=true immediately after that read, while PHP's native file:// handler only signals EOF after a subsequent empty read.

This made SplFileObject::seek(PHP_INT_MAX)->key() return one line too few for files ending with a newline, because the seek loop checked stream_eof() as its exit condition and stopped one iteration early.

Fix: NativeWrapper::stream_eof() now tracks whether a stream_read() call returned empty/false data, and stream_seek() resets the flag so repeated reads after a rewind still work correctly.

Closes #50