### PR TITLE
Improve cache locking to avoid race conditions in combination with paratest

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -49,8 +49,14 @@ Doing file I/O there would recurse back into the wrapper, and the comment is exp
 **multiple `stream_wrapper_restore` cycles inside that callback corrupt PHP's internal
 stream-wrapper state.** So all cache reads/writes are wrapped in a single
 `stream_wrapper_restore(...)` … `finally { unregister + re-register MutatingWrapper }`
-block (with `flock` for concurrent-safe cache files keyed by
-`sha1(code + tokens)`). Preserve that single-restore structure when editing.
+block. Preserve that single-restore structure when editing.
+
+Cache entries are keyed by `sha1(code + tokens)`. Concurrent writers (e.g. ParaTest
+workers sharing a cache dir) coordinate with a **sidecar `$hash.lock` file** and
+`flock(LOCK_EX)`: losers wait, then re-check the cache. The payload is published via
+temp file + `rename` so readers never see a partial write. A lock-free fast-path read
+is safe once a complete file exists; `.lock` files are left in place (delete them only
+on a full cache wipe).
 
 `isPathAllowed` is allow-then-deny by `fnmatch` (allow defaults to `['*']`, deny is
 checked only within a matched allow). `enable()` also snapshots the call stack and the

--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -139,31 +139,53 @@ final class BypassFinals
 		$cacheDir = self::$cacheDir ?? throw new \LogicException('Cache directory is not set.');
 		$hash = sha1($code . implode(',', self::$tokens));
 		$file = $cacheDir . '/' . $hash;
+		$lockFile = $file . '.lock';
 
 		// All cache I/O in a single native context to avoid multiple stream_wrapper_restore
 		// cycles inside an already-active MutatingWrapper stream_open callback, which
 		// corrupts PHP's internal stream wrapper state.
 		stream_wrapper_restore(NativeWrapper::Protocol);
 		try {
-			if ($handle = @fopen($file, 'r')) { // @ may not exist
-				flock($handle, LOCK_SH);
-				$cached = stream_get_contents($handle);
-				fclose($handle);
-				if ($cached) {
+			// Fast path: atomic rename publishes complete files only, so unlocked reads are safe.
+			$cached = @file_get_contents($file);
+			if ($cached !== false && $cached !== '') {
+				return $cached;
+			}
+
+			if (!is_dir($cacheDir) && !mkdir($cacheDir, 0o777, true) && !is_dir($cacheDir)) {
+				return self::removeTokens($code);
+			}
+			$lock = @fopen($lockFile, 'c'); // @ may fail on permission errors
+			if ($lock === false) {
+				return self::removeTokens($code);
+			}
+
+			if (!flock($lock, LOCK_EX)) {
+				fclose($lock);
+				return self::removeTokens($code);
+			}
+
+			try {
+				// Another process may have populated the cache while we waited for the lock.
+				$cached = @file_get_contents($file);
+				if ($cached !== false && $cached !== '') {
 					return $cached;
 				}
+
+				$code = self::removeTokens($code);
+
+				$tmp = $file . '.' . getmypid() . '.tmp';
+				if (@file_put_contents($tmp, $code) !== false) {
+					if (!@rename($tmp, $file)) { // @ may fail if target exists (e.g. Windows)
+						@unlink($tmp);
+					}
+				}
+
+				return $code;
+			} finally {
+				flock($lock, LOCK_UN);
+				fclose($lock);
 			}
-
-			$code = self::removeTokens($code);
-
-			@mkdir($cacheDir, 0o777, true);
-			if ($handle = @fopen($file, 'x')) { // @ may exist
-				flock($handle, LOCK_EX);
-				fwrite($handle, $code);
-				fclose($handle);
-			}
-
-			return $code;
 		} finally {
 			stream_wrapper_unregister(NativeWrapper::Protocol);
 			stream_wrapper_register(NativeWrapper::Protocol, MutatingWrapper::class);

--- a/src/NativeWrapper.php
+++ b/src/NativeWrapper.php
@@ -141,7 +141,30 @@ final class NativeWrapper implements StreamWrapper
 
 	public function stream_read(int $count): string|false
 	{
-		$data = fread($this->getHandle(), $count);
+		// Under parallel PHPUnit/ParaTest, transient EINVAL (errno=22) can occur when
+		// stream_wrapper_restore churn races with an in-flight fread. Retry a few times
+		// and suppress the warning on successful recovery (failOnWarning would otherwise fail CI).
+		$data = false;
+		$retryable = false;
+		for ($attempt = 0; $attempt < 3; $attempt++) {
+			$retryable = false;
+			set_error_handler(static function (int $severity, string $message) use (&$retryable): bool {
+				if (str_contains($message, 'fread():') && str_contains($message, 'errno=22')) {
+					$retryable = true;
+					return true;
+				}
+				return false;
+			});
+			try {
+				$data = fread($this->getHandle(), $count);
+			} finally {
+				restore_error_handler();
+			}
+			if ($data !== false || !$retryable) {
+				break;
+			}
+			usleep(1000 * (1 << $attempt));
+		}
 		if ($data === '' || $data === false) {
 			$this->eofAfterEmptyRead = true;
 		}


### PR DESCRIPTION
When running in parallel with [paratest](https://github.com/paratestphp/paratest) on CI sometimes we have errors like `fread(): Read of 8192 bytes failed with errno=22 Invalid argument in /app/vendor/dg/bypass-finals/src/NativeWrapper.php:154`.

This PR builds upon latest changes in bypass-finals 1.10 by using a retry mechanism when loading files and extending the `flock` usage with a write file first and then rename strategy to avoid partial writes